### PR TITLE
Feat/get summoner

### DIFF
--- a/services/lol-metrics-back/openapi.yaml
+++ b/services/lol-metrics-back/openapi.yaml
@@ -22,6 +22,38 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Champion"
+  /summoner:
+    get:
+      summary: Get summoner info with last matches
+      parameters:
+        - in: query
+          name: name
+          schema:
+            type: string
+          required: true
+          description: Player name
+          example: "TottiSkyZz"
+        - in: query
+          name: tagLine
+          schema:
+            type: string
+          required: true
+          description: Player tag line
+          example: "8256"
+        - in: query
+          name: platformId
+          schema:
+            type: string
+          required: true
+          description: Player platform ID
+          example: "EUW1"
+      responses:
+        "200":
+          description: Summoner info with last matches
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Summoner"
 
 components:
   schemas:
@@ -254,3 +286,97 @@ components:
         - icon
         - video
         - description
+
+    Summoner:
+      type: object
+      properties:
+        name:
+          type: string
+          example: "TottiSkyZz"
+        tagLine:
+          type: string
+          example: "8256"
+        profileIconId:
+          type: integer
+          example: 488
+        revisionDate:
+          type: integer
+          example: 1700000000000
+        summonerLevel:
+          type: integer
+          example: 30
+        lastMatches:
+          type: array
+          items:
+            $ref: "#/components/schemas/Match"
+      required:
+        - name
+        - tagLine
+        - profileIconId
+        - revisionDate
+        - summonerLevel
+
+    Match:
+      type: object
+      properties:
+        gameDuration:
+          type: integer
+          example: 1800
+          description: Duration of the match in seconds
+        gameCreation:
+          type: integer
+          example: 1670000000000
+          description: Unix timestamp (ms) of match creation
+        playerStats:
+          type: object
+          properties:
+            championId:
+              type: integer
+              example: 103
+            kills:
+              type: integer
+              example: 10
+            deaths:
+              type: integer
+              example: 2
+            assists:
+              type: integer
+              example: 5
+            cs:
+              type: integer
+              example: 200
+            win:
+              type: boolean
+              example: true
+            role:
+              type: string
+              items:
+                $ref: "#/components/schemas/Role"
+            items:
+              type: array
+              items:
+                type: integer
+              example: [1055, 3006, 3087, 3031, 3074, 3046]
+            killParticipation:
+              type: number
+              format: float
+              example: 0.75
+          required:
+            - championId
+            - kills
+            - deaths
+            - assists
+            - cs
+            - win
+            - role
+            - items
+        championIdsInMatch:
+          type: array
+          items:
+            type: integer
+          example: [103, 45, 240, 7, 12, 64, 99, 33, 55, 120]
+      required:
+        - gameDuration
+        - gameCreation
+        - playerStats
+        - championIdsInMatch

--- a/services/lol-metrics-back/src/controllers/summoner.controller.ts
+++ b/services/lol-metrics-back/src/controllers/summoner.controller.ts
@@ -8,10 +8,7 @@ import { riotIdToSummoner } from "@/services/summoners.service";
 import { RiotPlatformId } from "@/utils/riotRouting";
 import { Request, Response } from "express";
 
-export const searchSummonersController = async (
-  req: Request,
-  res: Response
-) => {
+export const searchSummonerController = async (req: Request, res: Response) => {
   try {
     const name = req.query.name as string;
     const tagLine = req.query.tagLine as string;
@@ -28,17 +25,21 @@ export const searchSummonersController = async (
     res.status(200).json(summoner);
   } catch (error: any) {
     console.log(error);
-    if (error instanceof UnauthorizedError) {
-      res.status(401).json({ message: error.message });
-    } else if (error instanceof ForbiddenError) {
-      res.status(403).json({ message: error.message });
-    } else if (error instanceof NotFoundError) {
-      res.status(404).json({ message: error.message });
-    } else if (error instanceof RateLimitError) {
-      res.status(429).json({ message: error.message });
-    } else {
-      console.error(error);
-      res.status(500).json({ message: "Internal server error" });
-    }
+    handleRiotErrors(error, res);
+  }
+};
+
+const handleRiotErrors = (error: any, res: Response) => {
+  if (error instanceof UnauthorizedError) {
+    res.status(401).json({ message: error.message });
+  } else if (error instanceof ForbiddenError) {
+    res.status(403).json({ message: error.message });
+  } else if (error instanceof NotFoundError) {
+    res.status(404).json({ message: error.message });
+  } else if (error instanceof RateLimitError) {
+    res.status(429).json({ message: error.message });
+  } else {
+    console.error(error);
+    res.status(500).json({ message: "Internal server error" });
   }
 };

--- a/services/lol-metrics-back/src/controllers/summoner.controller.ts
+++ b/services/lol-metrics-back/src/controllers/summoner.controller.ts
@@ -1,0 +1,44 @@
+import {
+  ForbiddenError,
+  NotFoundError,
+  RateLimitError,
+  UnauthorizedError,
+} from "@/errors/errors";
+import { riotIdToSummoner } from "@/services/summoners.service";
+import { RiotPlatformId } from "@/utils/riotRouting";
+import { Request, Response } from "express";
+
+export const searchSummonersController = async (
+  req: Request,
+  res: Response
+) => {
+  try {
+    const name = req.query.name as string;
+    const tagLine = req.query.tagLine as string;
+    const platformId = req.query.platformId as RiotPlatformId;
+
+    if (!name || !tagLine || !platformId) {
+      res
+        .status(400)
+        .json({ message: "Missing name, tagLine or platformId query params" });
+      return;
+    }
+
+    const summoner = await riotIdToSummoner(name, tagLine, platformId);
+    res.status(200).json(summoner);
+  } catch (error: any) {
+    console.log(error);
+    if (error instanceof UnauthorizedError) {
+      res.status(401).json({ message: error.message });
+    } else if (error instanceof ForbiddenError) {
+      res.status(403).json({ message: error.message });
+    } else if (error instanceof NotFoundError) {
+      res.status(404).json({ message: error.message });
+    } else if (error instanceof RateLimitError) {
+      res.status(429).json({ message: error.message });
+    } else {
+      console.error(error);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  }
+};

--- a/services/lol-metrics-back/src/errors/errors.ts
+++ b/services/lol-metrics-back/src/errors/errors.ts
@@ -1,0 +1,40 @@
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+export class UnauthorizedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnauthorizedError";
+  }
+}
+
+export class BadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BadRequestError";
+  }
+}
+
+export class ForbiddenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ForbiddenError";
+  }
+}
+
+export class RateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RateLimitError";
+  }
+}
+export class InternalServerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InternalServerError";
+  }
+}

--- a/services/lol-metrics-back/src/models/Champion.ts
+++ b/services/lol-metrics-back/src/models/Champion.ts
@@ -1,5 +1,0 @@
-// export interface Champion {
-//   id: string;
-//   name: string;
-//   role: string;
-// }

--- a/services/lol-metrics-back/src/routes.ts
+++ b/services/lol-metrics-back/src/routes.ts
@@ -4,6 +4,7 @@ import {
   getChampionByIdController,
   getChampionsController,
 } from "./controllers/champions.controller";
+import { searchSummonersController } from "./controllers/summoner.controller";
 // IMPORT ROUTER
 
 const router = Router();
@@ -23,7 +24,7 @@ router.get("/champions/:id", getChampionByIdController);
 
 // SUMMONER
 // Summoners list (with queryParam)
-// router.get('/summoners', searchSummoners);
+router.get("/summoners", searchSummonersController);
 
 // Summoner (queryParam moreDetails -->  rank + mastery)
 // router.get('/summoners/:summonerName', searchSummonerByName )

--- a/services/lol-metrics-back/src/routes.ts
+++ b/services/lol-metrics-back/src/routes.ts
@@ -4,7 +4,7 @@ import {
   getChampionByIdController,
   getChampionsController,
 } from "./controllers/champions.controller";
-import { searchSummonersController } from "./controllers/summoner.controller";
+import { searchSummonerController } from "./controllers/summoner.controller";
 // IMPORT ROUTER
 
 const router = Router();
@@ -24,7 +24,7 @@ router.get("/champions/:id", getChampionByIdController);
 
 // SUMMONER
 // Summoners list (with queryParam)
-router.get("/summoners", searchSummonersController);
+router.get("/summoner", searchSummonerController);
 
 // Summoner (queryParam moreDetails -->  rank + mastery)
 // router.get('/summoners/:summonerName', searchSummonerByName )

--- a/services/lol-metrics-back/src/services/champions.service.ts
+++ b/services/lol-metrics-back/src/services/champions.service.ts
@@ -6,17 +6,13 @@ import {
   CdragonSpell,
   SpellKey,
 } from "@/types/cdragon";
-import { components } from "@/types/openapi";
 import { toCDragonUrl, toCDragonUrlVideo } from "@/utils/cdragon";
 import axios from "axios";
 import { fetchSkins, findBaseSkinForChampion } from "@/services/skins.service";
 import championsSupplementaryData from "@/data/champions.json";
 import { ChampionSupplementaryData } from "@/types/supplementaryDatas";
 import { MAChampion } from "@/types/merakiAnalytics";
-
-type Champion = components["schemas"]["Champion"];
-type ChampionDetails = components["schemas"]["ChampionDetails"];
-type Spell = components["schemas"]["Spell"];
+import { Champion, ChampionDetails, Skin, Spell } from "@/types";
 
 export const getAllChampions = async (): Promise<Champion[]> => {
   const summaryUrl = `${process.env.COMMUNITY_DRAGON_API_URL}/v1/champion-summary.json`;
@@ -66,21 +62,19 @@ export const getChampionById = async (id: string): Promise<ChampionDetails> => {
   const skins = data.skins;
   const championDetailFromMA = await getChampionFromMA(data.alias);
 
-  const pricedSkins: components["schemas"]["Skin"][] = skins.map(
-    (skin: CdragonSkinSummary) => {
-      const matchingSkin = championDetailFromMA.skins.find(
-        (s: any) => s.id === skin.id
-      );
-      return {
-        id: skin.id,
-        name: skin.name,
-        isBase: skin.isBase,
-        image: toCDragonUrl(skin.uncenteredSplashPath),
-        rarity: skin.rarity ?? matchingSkin?.rarity ?? "Unknown",
-        price: matchingSkin?.cost ?? "Unknown",
-      };
-    }
-  );
+  const pricedSkins: Skin[] = skins.map((skin: CdragonSkinSummary) => {
+    const matchingSkin = championDetailFromMA.skins.find(
+      (s: any) => s.id === skin.id
+    );
+    return {
+      id: skin.id,
+      name: skin.name,
+      isBase: skin.isBase,
+      image: toCDragonUrl(skin.uncenteredSplashPath),
+      rarity: skin.rarity ?? matchingSkin?.rarity ?? "Unknown",
+      price: matchingSkin?.cost ?? "Unknown",
+    };
+  });
 
   // SPELLS
   const spellsByKey = Object.fromEntries(
@@ -136,7 +130,9 @@ const spellByKey = (
   };
 };
 
-export const getChampionFromMA = async (champAlias: string) => {
+export const getChampionFromMA = async (
+  champAlias: string
+): Promise<MAChampion> => {
   const merakianalyticsUrl = `${process.env.MA_URL}/resources/latest/en-US/champions/${champAlias}.json`;
   const { data } = await axios.get<MAChampion>(merakianalyticsUrl);
   return data;

--- a/services/lol-metrics-back/src/services/summoners.service.ts
+++ b/services/lol-metrics-back/src/services/summoners.service.ts
@@ -1,0 +1,79 @@
+import {
+  ForbiddenError,
+  NotFoundError,
+  RateLimitError,
+  UnauthorizedError,
+} from "@/errors/errors";
+import {
+  getAccountApiUrl,
+  getPlatformApiUrl,
+  RiotPlatformId,
+} from "@/utils/riotRouting";
+import axios from "axios";
+
+export const riotIdToSummoner = async (
+  gameName: string,
+  tagLine: string,
+  platformId: RiotPlatformId
+) => {
+  const accountUrl = getAccountApiUrl(platformId);
+  const platformUrl = getPlatformApiUrl(platformId);
+
+  if (!accountUrl || !platformUrl) {
+    throw new Error("Invalid platform ID");
+  }
+
+  try {
+    const riotAccount = await axios.get(
+      `${accountUrl}/riot/account/v1/accounts/by-riot-id/${gameName}/${tagLine}`,
+      {
+        headers: {
+          "X-Riot-Token": process.env.RIOT_API_KEY!,
+        },
+      }
+    );
+
+    if (!riotAccount.data) {
+      throw new NotFoundError("Riot account not found");
+    }
+
+    console.log(riotAccount.data);
+
+    const puuid = riotAccount.data.puuid;
+
+    const summonerData = await axios.get(
+      `${platformUrl}/lol/summoner/v4/summoners/by-puuid/${puuid}`,
+      {
+        headers: {
+          "X-Riot-Token": process.env.RIOT_API_KEY!,
+        },
+      }
+    );
+
+    console.log(summonerData.data);
+
+    if (!summonerData.data) {
+      throw new NotFoundError("Summoner data not found");
+    }
+
+    return summonerData.data;
+  } catch (error: any) {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status;
+
+      switch (status) {
+        case 401:
+          throw new UnauthorizedError("Invalid API key");
+        case 403:
+          throw new ForbiddenError("Forbidden access");
+        case 404:
+          throw new NotFoundError("Summoner not found");
+        case 429:
+          throw new RateLimitError("Rate limit exceeded");
+        default:
+          throw new Error(error.message);
+      }
+    }
+    throw error;
+  }
+};

--- a/services/lol-metrics-back/src/services/summoners.service.ts
+++ b/services/lol-metrics-back/src/services/summoners.service.ts
@@ -4,9 +4,12 @@ import {
   RateLimitError,
   UnauthorizedError,
 } from "@/errors/errors";
+import { Match, Summoner } from "@/types";
+import { MatchDto } from "@/types/riot";
 import {
   getAccountApiUrl,
   getPlatformApiUrl,
+  normalizeRole,
   RiotPlatformId,
 } from "@/utils/riotRouting";
 import axios from "axios";
@@ -15,7 +18,7 @@ export const riotIdToSummoner = async (
   gameName: string,
   tagLine: string,
   platformId: RiotPlatformId
-) => {
+): Promise<Summoner> => {
   const accountUrl = getAccountApiUrl(platformId);
   const platformUrl = getPlatformApiUrl(platformId);
 
@@ -37,8 +40,6 @@ export const riotIdToSummoner = async (
       throw new NotFoundError("Riot account not found");
     }
 
-    console.log(riotAccount.data);
-
     const puuid = riotAccount.data.puuid;
 
     const summonerData = await axios.get(
@@ -50,13 +51,16 @@ export const riotIdToSummoner = async (
       }
     );
 
-    console.log(summonerData.data);
-
     if (!summonerData.data) {
       throw new NotFoundError("Summoner data not found");
     }
 
-    return summonerData.data;
+    const lastMatches = await getLastMatchesByPuuid(puuid, platformId);
+
+    return {
+      ...summonerData.data,
+      lastMatches,
+    };
   } catch (error: any) {
     if (axios.isAxiosError(error)) {
       const status = error.response?.status;
@@ -77,3 +81,91 @@ export const riotIdToSummoner = async (
     throw error;
   }
 };
+
+export const getLastMatchesByPuuid = async (
+  puuid: string,
+  platformId: RiotPlatformId,
+  count = 5
+): Promise<Match[]> => {
+  const accountUrl = getAccountApiUrl(platformId);
+
+  try {
+    const matchesResponse = await axios.get(
+      `${accountUrl}/lol/match/v5/matches/by-puuid/${puuid}/ids`,
+      {
+        headers: { "X-Riot-Token": process.env.RIOT_API_KEY! },
+        params: {
+          count,
+        },
+      }
+    );
+
+    if (matchesResponse.data?.length === 0) {
+      return [];
+    }
+
+    const matchIds: string[] = matchesResponse.data;
+
+    const matchDetailsPromises = matchIds.map(async (matchId) => {
+      const response = await axios.get<MatchDto>(
+        `${accountUrl}/lol/match/v5/matches/${matchId}`,
+        {
+          headers: { "X-Riot-Token": process.env.RIOT_API_KEY! },
+        }
+      );
+      return simplifyLastMatch(response.data, puuid);
+    });
+
+    return await Promise.all(matchDetailsPromises);
+  } catch (error: any) {
+    console.warn(
+      `Error fetching last matches for PUUID ${puuid}:`,
+      error.message
+    );
+    return [];
+  }
+};
+
+function simplifyLastMatch(matchDto: MatchDto, targetPuuid: string): Match {
+  const { gameDuration, gameCreation, participants } = matchDto.info;
+
+  const player = participants.find((p) => p.puuid === targetPuuid)!;
+
+  const championIdsInMatch = participants.map((p) => p.championId);
+
+  const totalTeamKills = participants
+    .filter((p) => p.teamId === player.teamId)
+    .reduce((acc, p) => acc + p.kills, 0);
+
+  const killParticipation =
+    totalTeamKills > 0
+      ? Math.round(((player.kills + player.assists) / totalTeamKills) * 100)
+      : 0;
+
+  const items = [
+    player.item0,
+    player.item1,
+    player.item2,
+    player.item3,
+    player.item4,
+    player.item5,
+    player.item6,
+  ].filter((i) => i !== 0);
+
+  return {
+    gameDuration,
+    gameCreation,
+    playerStats: {
+      championId: player.championId,
+      kills: player.kills,
+      deaths: player.deaths,
+      assists: player.assists,
+      cs: player.totalMinionsKilled + player.neutralMinionsKilled,
+      win: player.win,
+      role: normalizeRole(player.teamPosition),
+      items,
+      killParticipation,
+    },
+    championIdsInMatch,
+  };
+}

--- a/services/lol-metrics-back/src/types/cdragon.ts
+++ b/services/lol-metrics-back/src/types/cdragon.ts
@@ -1,6 +1,4 @@
-import { components } from "./openapi";
-
-export type Role = components["schemas"]["Role"];
+import { Role } from "@/types";
 export type SpellKey = "q" | "w" | "e" | "r" | "p";
 
 export interface CDragonChampionSummary {

--- a/services/lol-metrics-back/src/types/index.ts
+++ b/services/lol-metrics-back/src/types/index.ts
@@ -1,0 +1,9 @@
+import { components } from "./openapi";
+
+export type Champion = components["schemas"]["Champion"];
+export type ChampionDetails = components["schemas"]["ChampionDetails"];
+export type Spell = components["schemas"]["Spell"];
+export type Skin = components["schemas"]["Skin"];
+export type Match = components["schemas"]["Match"];
+export type Role = components["schemas"]["Role"];
+export type Summoner = components["schemas"]["Summoner"];

--- a/services/lol-metrics-back/src/types/openapi.ts
+++ b/services/lol-metrics-back/src/types/openapi.ts
@@ -43,6 +43,58 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/summoner": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get summoner info with last matches */
+        get: {
+            parameters: {
+                query: {
+                    /**
+                     * @description Player name
+                     * @example TottiSkyZz
+                     */
+                    name: string;
+                    /**
+                     * @description Player tag line
+                     * @example 8256
+                     */
+                    tagLine: string;
+                    /**
+                     * @description Player platform ID
+                     * @example EUW1
+                     */
+                    platformId: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Summoner info with last matches */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Summoner"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -211,6 +263,73 @@ export interface components {
              * @example Annie hurls a Mana infused fireball, dealing damage and refunding the Mana cost if it destroys the target.
              */
             description: string;
+        };
+        Summoner: {
+            /** @example TottiSkyZz */
+            name: string;
+            /** @example 8256 */
+            tagLine: string;
+            /** @example 488 */
+            profileIconId: number;
+            /** @example 1700000000000 */
+            revisionDate: number;
+            /** @example 30 */
+            summonerLevel: number;
+            lastMatches?: components["schemas"]["Match"][];
+        };
+        Match: {
+            /**
+             * @description Duration of the match in seconds
+             * @example 1800
+             */
+            gameDuration: number;
+            /**
+             * @description Unix timestamp (ms) of match creation
+             * @example 1670000000000
+             */
+            gameCreation: number;
+            playerStats: {
+                /** @example 103 */
+                championId: number;
+                /** @example 10 */
+                kills: number;
+                /** @example 2 */
+                deaths: number;
+                /** @example 5 */
+                assists: number;
+                /** @example 200 */
+                cs: number;
+                /** @example true */
+                win: boolean;
+                role: string;
+                /** @example [
+                 *       1055,
+                 *       3006,
+                 *       3087,
+                 *       3031,
+                 *       3074,
+                 *       3046
+                 *     ] */
+                items: number[];
+                /**
+                 * Format: float
+                 * @example 0.75
+                 */
+                killParticipation?: number;
+            };
+            /** @example [
+             *       103,
+             *       45,
+             *       240,
+             *       7,
+             *       12,
+             *       64,
+             *       99,
+             *       33,
+             *       55,
+             *       120
+             *     ] */
+            championIdsInMatch: number[];
         };
     };
     responses: never;

--- a/services/lol-metrics-back/src/types/riot.ts
+++ b/services/lol-metrics-back/src/types/riot.ts
@@ -1,0 +1,385 @@
+export interface MatchDto {
+  metadata: MetadataDto;
+  info: InfoDto;
+}
+
+export interface MetadataDto {
+  dataVersion: string;
+  matchId: string;
+  participants: string[];
+}
+
+export interface InfoDto {
+  endOfGameResult: string;
+  gameCreation: number;
+  gameDuration: number;
+  gameEndTimestamp?: number;
+  gameId: number;
+  gameMode: string;
+  gameName: string;
+  gameStartTimestamp: number;
+  gameType: string;
+  gameVersion: string;
+  mapId: number;
+  participants: ParticipantDto[];
+  platformId: string;
+  queueId: number;
+  teams: TeamDto[];
+  tournamentCode?: string;
+}
+
+export interface ParticipantDto {
+  allInPings: number;
+  assistMePings: number;
+  assists: number;
+  baronKills: number;
+  bountyLevel: number;
+  champExperience: number;
+  champLevel: number;
+  championId: number;
+  championName: string;
+  commandPings: number;
+  championTransform: number;
+  consumablesPurchased: number;
+  challenges: ChallengesDto;
+  damageDealtToBuildings: number;
+  damageDealtToObjectives: number;
+  damageDealtToTurrets: number;
+  damageSelfMitigated: number;
+  deaths: number;
+  detectorWardsPlaced: number;
+  doubleKills: number;
+  dragonKills: number;
+  eligibleForProgression: boolean;
+  enemyMissingPings: number;
+  enemyVisionPings: number;
+  firstBloodAssist: boolean;
+  firstBloodKill: boolean;
+  firstTowerAssist: boolean;
+  firstTowerKill: boolean;
+  gameEndedInEarlySurrender: boolean;
+  gameEndedInSurrender: boolean;
+  holdPings: number;
+  getBackPings: number;
+  goldEarned: number;
+  goldSpent: number;
+  individualPosition: string;
+  inhibitorKills: number;
+  inhibitorTakedowns: number;
+  inhibitorsLost: number;
+  item0: number;
+  item1: number;
+  item2: number;
+  item3: number;
+  item4: number;
+  item5: number;
+  item6: number;
+  itemsPurchased: number;
+  killingSprees: number;
+  kills: number;
+  lane: string;
+  largestCriticalStrike: number;
+  largestKillingSpree: number;
+  largestMultiKill: number;
+  longestTimeSpentLiving: number;
+  magicDamageDealt: number;
+  magicDamageDealtToChampions: number;
+  magicDamageTaken: number;
+  missions: MissionsDto;
+  neutralMinionsKilled: number;
+  needVisionPings: number;
+  nexusKills: number;
+  nexusTakedowns: number;
+  nexusLost: number;
+  objectivesStolen: number;
+  objectivesStolenAssists: number;
+  onMyWayPings: number;
+  participantId: number;
+  playerScore0: number;
+  playerScore1: number;
+  playerScore2: number;
+  playerScore3: number;
+  playerScore4: number;
+  playerScore5: number;
+  playerScore6: number;
+  playerScore7: number;
+  playerScore8: number;
+  playerScore9: number;
+  playerScore10: number;
+  playerScore11: number;
+  pentaKills: number;
+  perks: PerksDto;
+  physicalDamageDealt: number;
+  physicalDamageDealtToChampions: number;
+  physicalDamageTaken: number;
+  placement: number;
+  playerAugment1: number;
+  playerAugment2: number;
+  playerAugment3: number;
+  playerAugment4: number;
+  playerSubteamId: number;
+  pushPings: number;
+  profileIcon: number;
+  puuid: string;
+  quadraKills: number;
+  riotIdGameName: string;
+  riotIdTagline: string;
+  role: string;
+  sightWardsBoughtInGame: number;
+  spell1Casts: number;
+  spell2Casts: number;
+  spell3Casts: number;
+  spell4Casts: number;
+  subteamPlacement: number;
+  summoner1Casts: number;
+  summoner1Id: number;
+  summoner2Casts: number;
+  summoner2Id: number;
+  summonerId: string;
+  summonerLevel: number;
+  summonerName: string;
+  teamEarlySurrendered: boolean;
+  teamId: number;
+  teamPosition: string;
+  timeCCingOthers: number;
+  timePlayed: number;
+  totalAllyJungleMinionsKilled: number;
+  totalDamageDealt: number;
+  totalDamageDealtToChampions: number;
+  totalDamageShieldedOnTeammates: number;
+  totalDamageTaken: number;
+  totalEnemyJungleMinionsKilled: number;
+  totalHeal: number;
+  totalHealsOnTeammates: number;
+  totalMinionsKilled: number;
+  totalTimeCCDealt: number;
+  totalTimeSpentDead: number;
+  totalUnitsHealed: number;
+  tripleKills: number;
+  trueDamageDealt: number;
+  trueDamageDealtToChampions: number;
+  trueDamageTaken: number;
+  turretKills: number;
+  turretTakedowns: number;
+  turretsLost: number;
+  unrealKills: number;
+  visionScore: number;
+  visionClearedPings: number;
+  visionWardsBoughtInGame: number;
+  wardsKilled: number;
+  wardsPlaced: number;
+  win: boolean;
+}
+
+export interface ChallengesDto {
+  "12AssistStreakCount": number;
+  baronBuffGoldAdvantageOverThreshold: number;
+  controlWardTimeCoverageInRiverOrEnemyHalf: number;
+  earliestBaron: number;
+  earliestDragonTakedown: number;
+  earliestElderDragon: number;
+  earlyLaningPhaseGoldExpAdvantage: number;
+  fasterSupportQuestCompletion: number;
+  fastestLegendary: number;
+  hadAfkTeammate: number;
+  highestChampionDamage: number;
+  highestCrowdControlScore: number;
+  highestWardKills: number;
+  junglerKillsEarlyJungle: number;
+  killsOnLanersEarlyJungleAsJungler: number;
+  laningPhaseGoldExpAdvantage: number;
+  legendaryCount: number;
+  maxCsAdvantageOnLaneOpponent: number;
+  maxLevelLeadLaneOpponent: number;
+  mostWardsDestroyedOneSweeper: number;
+  mythicItemUsed: number;
+  playedChampSelectPosition: number;
+  soloTurretsLategame: number;
+  takedownsFirst25Minutes: number;
+  teleportTakedowns: number;
+  thirdInhibitorDestroyedTime: number;
+  threeWardsOneSweeperCount: number;
+  visionScoreAdvantageLaneOpponent: number;
+  InfernalScalePickup: number;
+  fistBumpParticipation: number;
+  voidMonsterKill: number;
+  abilityUses: number;
+  acesBefore15Minutes: number;
+  alliedJungleMonsterKills: number;
+  baronTakedowns: number;
+  blastConeOppositeOpponentCount: number;
+  bountyGold: number;
+  buffsStolen: number;
+  completeSupportQuestInTime: number;
+  controlWardsPlaced: number;
+  damagePerMinute: number;
+  damageTakenOnTeamPercentage: number;
+  dancedWithRiftHerald: number;
+  deathsByEnemyChamps: number;
+  dodgeSkillShotsSmallWindow: number;
+  doubleAces: number;
+  dragonTakedowns: number;
+  legendaryItemUsed: number[];
+  effectiveHealAndShielding: number;
+  elderDragonKillsWithOpposingSoul: number;
+  elderDragonMultikills: number;
+  enemyChampionImmobilizations: number;
+  enemyJungleMonsterKills: number;
+  epicMonsterKillsNearEnemyJungler: number;
+  epicMonsterKillsWithin30SecondsOfSpawn: number;
+  epicMonsterSteals: number;
+  epicMonsterStolenWithoutSmite: number;
+  firstTurretKilled: number;
+  firstTurretKilledTime: number;
+  flawlessAces: number;
+  fullTeamTakedown: number;
+  gameLength: number;
+  getTakedownsInAllLanesEarlyJungleAsLaner: number;
+  goldPerMinute: number;
+  hadOpenNexus: number;
+  immobilizeAndKillWithAlly: number;
+  initialBuffCount: number;
+  initialCrabCount: number;
+  jungleCsBefore10Minutes: number;
+  junglerTakedownsNearDamagedEpicMonster: number;
+  kda: number;
+  killAfterHiddenWithAlly: number;
+  killedChampTookFullTeamDamageSurvived: number;
+  killingSprees: number;
+  killParticipation: number;
+  killsNearEnemyTurret: number;
+  killsOnOtherLanesEarlyJungleAsLaner: number;
+  killsOnRecentlyHealedByAramPack: number;
+  killsUnderOwnTurret: number;
+  killsWithHelpFromEpicMonster: number;
+  knockEnemyIntoTeamAndKill: number;
+  kTurretsDestroyedBeforePlatesFall: number;
+  landSkillShotsEarlyGame: number;
+  lostAnInhibitor: number;
+  maxKillDeficit: number;
+  mejaisFullStackInTime: number;
+  moreEnemyJungleThanOpponent: number;
+  multiKillOneSpell: number;
+  multikills: number;
+  multikillsAfterAggressiveFlash: number;
+  multiTurretRiftHeraldCount: number;
+  outerTurretExecutesBefore10Minutes: number;
+  outnumberedKills: number;
+  outnumberedNexusKill: number;
+  perfectDragonSoulsTaken: number;
+  perfectGame: number;
+  pickKillWithAlly: number;
+  poroExplosions: number;
+  quickCleanse: number;
+  quickFirstTurret: number;
+  quickSoloKills: number;
+  riftHeraldTakedowns: number;
+  saveAllyFromDeath: number;
+  scuttleCrabKills: number;
+  shortestTimeToAceFromFirstTakedown: number;
+  skillshotsDodged: number;
+  skillshotsHit: number;
+  snowballsHit: number;
+  soloBaronKills: number;
+  SWARM_DefeatAatrox: number;
+  SWARM_DefeatBriar: number;
+  SWARM_DefeatMiniBosses: number;
+  SWARM_EvolveWeapon: number;
+  SWARM_Have3Passives: number;
+  SWARM_KillEnemy: number;
+  SWARM_PickupGold: number;
+  SWARM_ReachLevel50: number;
+  SWARM_Survive15Min: number;
+  soloKills: number;
+  stealthWardsPlaced: number;
+  survivedSingleDigitHpCount: number;
+  survivedThreeImmobilizesInFight: number;
+  takedownOnFirstTurret: number;
+  takedowns: number;
+  takedownsAfterGainingLevelAdvantage: number;
+  takedownsBeforeJungleMinionSpawn: number;
+  takedownsFirstXMinutes: number;
+  takedownsInAlcove: number;
+  takedownsInEnemyFountain: number;
+  teamBaronKills: number;
+  teamDamagePercentage: number;
+  teamElderDragonKills: number;
+  teamRiftHeraldKills: number;
+  tookLargeDamageSurvived: number;
+  turretPlatesTaken: number;
+  turretsTakenWithRiftHerald: number;
+  turretTakedowns: number;
+  twentyMinionsIn3SecondsCount: number;
+  twoWardsOneSweeperCount: number;
+  unseenRecalls: number;
+  visionScorePerMinute: number;
+  wardsGuarded: number;
+  wardTakedowns: number;
+  wardTakedownsBefore20M: number;
+}
+
+export interface MissionsDto {
+  playerScore0: number;
+  playerScore1: number;
+  playerScore2: number;
+  playerScore3: number;
+  playerScore4: number;
+  playerScore5: number;
+  playerScore6: number;
+  playerScore7: number;
+  playerScore8: number;
+  playerScore9: number;
+  playerScore10: number;
+  playerScore11: number;
+}
+
+export interface PerksDto {
+  statPerks: PerkStatsDto;
+  styles: PerkStyleDto[];
+}
+
+export interface PerkStatsDto {
+  defense: number;
+  flex: number;
+  offense: number;
+}
+
+export interface PerkStyleDto {
+  description: string;
+  selections: PerkStyleSelectionDto[];
+  style: number;
+}
+
+export interface PerkStyleSelectionDto {
+  perk: number;
+  var1: number;
+  var2: number;
+  var3: number;
+}
+
+export interface TeamDto {
+  bans: BanDto[];
+  objectives: ObjectivesDto;
+  teamId: number;
+  win: boolean;
+}
+
+export interface BanDto {
+  championId: number;
+  pickTurn: number;
+}
+
+export interface ObjectivesDto {
+  baron: ObjectiveDto;
+  champion: ObjectiveDto;
+  dragon: ObjectiveDto;
+  horde: ObjectiveDto;
+  inhibitor: ObjectiveDto;
+  riftHerald: ObjectiveDto;
+  tower: ObjectiveDto;
+}
+
+export interface ObjectiveDto {
+  first: boolean;
+  kills: number;
+}

--- a/services/lol-metrics-back/src/utils/riotRouting.ts
+++ b/services/lol-metrics-back/src/utils/riotRouting.ts
@@ -1,0 +1,85 @@
+export enum RiotPlatformId {
+  EUW1 = "euw1",
+  EUN1 = "eun1",
+  TR1 = "tr1",
+  RU = "ru",
+  NA1 = "na1",
+  BR1 = "br1",
+  LA1 = "la1",
+  LA2 = "la2",
+  KR = "kr",
+  JP1 = "jp1",
+  OC1 = "oc1",
+  PH2 = "ph2",
+  SG2 = "sg2",
+  TH2 = "th2",
+  TW2 = "tw2",
+  VN2 = "vn2",
+}
+
+export enum RiotRoutingRegion {
+  EUROPE = "europe",
+  AMERICAS = "americas",
+  ASIA = "asia",
+  SEA = "sea",
+}
+
+export const RIOT_PLATFORM_TO_ROUTING: Record<
+  RiotPlatformId,
+  RiotRoutingRegion
+> = {
+  [RiotPlatformId.EUW1]: RiotRoutingRegion.EUROPE,
+  [RiotPlatformId.EUN1]: RiotRoutingRegion.EUROPE,
+  [RiotPlatformId.TR1]: RiotRoutingRegion.EUROPE,
+  [RiotPlatformId.RU]: RiotRoutingRegion.EUROPE,
+
+  [RiotPlatformId.NA1]: RiotRoutingRegion.AMERICAS,
+  [RiotPlatformId.BR1]: RiotRoutingRegion.AMERICAS,
+  [RiotPlatformId.LA1]: RiotRoutingRegion.AMERICAS,
+  [RiotPlatformId.LA2]: RiotRoutingRegion.AMERICAS,
+
+  [RiotPlatformId.KR]: RiotRoutingRegion.ASIA,
+  [RiotPlatformId.JP1]: RiotRoutingRegion.ASIA,
+
+  [RiotPlatformId.OC1]: RiotRoutingRegion.SEA,
+  [RiotPlatformId.PH2]: RiotRoutingRegion.SEA,
+  [RiotPlatformId.SG2]: RiotRoutingRegion.SEA,
+  [RiotPlatformId.TH2]: RiotRoutingRegion.SEA,
+  [RiotPlatformId.TW2]: RiotRoutingRegion.SEA,
+  [RiotPlatformId.VN2]: RiotRoutingRegion.SEA,
+};
+
+export const RIOT_ACCOUNT_BASE_URLS: Record<RiotRoutingRegion, string> = {
+  [RiotRoutingRegion.EUROPE]: "https://europe.api.riotgames.com",
+  [RiotRoutingRegion.AMERICAS]: "https://americas.api.riotgames.com",
+  [RiotRoutingRegion.ASIA]: "https://asia.api.riotgames.com",
+  [RiotRoutingRegion.SEA]: "https://sea.api.riotgames.com",
+};
+
+export const RIOT_PLATFORM_BASE_URLS: Record<RiotPlatformId, string> = {
+  [RiotPlatformId.EUW1]: "https://euw1.api.riotgames.com",
+  [RiotPlatformId.EUN1]: "https://eun1.api.riotgames.com",
+  [RiotPlatformId.TR1]: "https://tr1.api.riotgames.com",
+  [RiotPlatformId.RU]: "https://ru.api.riotgames.com",
+  [RiotPlatformId.NA1]: "https://na1.api.riotgames.com",
+  [RiotPlatformId.BR1]: "https://br1.api.riotgames.com",
+  [RiotPlatformId.LA1]: "https://la1.api.riotgames.com",
+  [RiotPlatformId.LA2]: "https://la2.api.riotgames.com",
+  [RiotPlatformId.KR]: "https://kr.api.riotgames.com",
+  [RiotPlatformId.JP1]: "https://jp1.api.riotgames.com",
+  [RiotPlatformId.OC1]: "https://oc1.api.riotgames.com",
+  [RiotPlatformId.PH2]: "https://ph2.api.riotgames.com",
+  [RiotPlatformId.SG2]: "https://sg2.api.riotgames.com",
+  [RiotPlatformId.TH2]: "https://th2.api.riotgames.com",
+  [RiotPlatformId.TW2]: "https://tw2.api.riotgames.com",
+  [RiotPlatformId.VN2]: "https://vn2.api.riotgames.com",
+};
+
+export function getAccountApiUrl(platformId: RiotPlatformId): string {
+  const routingRegion = RIOT_PLATFORM_TO_ROUTING[platformId];
+  return RIOT_ACCOUNT_BASE_URLS[routingRegion];
+}
+
+export function getPlatformApiUrl(platformId: RiotPlatformId): string {
+  return RIOT_PLATFORM_BASE_URLS[platformId];
+}

--- a/services/lol-metrics-back/src/utils/riotRouting.ts
+++ b/services/lol-metrics-back/src/utils/riotRouting.ts
@@ -83,3 +83,21 @@ export function getAccountApiUrl(platformId: RiotPlatformId): string {
 export function getPlatformApiUrl(platformId: RiotPlatformId): string {
   return RIOT_PLATFORM_BASE_URLS[platformId];
 }
+
+// TODO : Check a better way to normalize roles
+export function normalizeRole(role: string): string {
+  switch (role) {
+    case "MIDDLE":
+      return "Mid";
+    case "TOP":
+      return "Top";
+    case "SUPPORT":
+      return "Support";
+    case "BOTTOM":
+      return "Bottom";
+    case "JUNGLE":
+      return "Jungle";
+    default:
+      return role;
+  }
+}


### PR DESCRIPTION
This pull request introduces a new feature to fetch summoner information along with their last matches from the Riot Games API. It includes updates to the OpenAPI specification, new API endpoints, error handling, and refactoring of existing types and services to support the new functionality.

### New Feature: Summoner Info API

* **OpenAPI Specification Updates**:
  - Added a new `/summoner` endpoint to the `openapi.yaml` file for retrieving summoner information and their last matches. This endpoint includes query parameters for `name`, `tagLine`, and `platformId`, and returns a `Summoner` object.
  - Added `Summoner` and `Match` schemas to the OpenAPI components to define the structure of the summoner data and match details.

* **New Summoner Controller and Service**:
  - Implemented `searchSummonerController` in `summoner.controller.ts` to handle requests to the `/summoner` endpoint. This controller validates input, calls the service, and handles errors.
  - Added `riotIdToSummoner` and `getLastMatchesByPuuid` functions in `summoners.service.ts` to fetch summoner data and their last match details from the Riot Games API. Includes error handling for API responses.

### Error Handling Enhancements

* **Custom Error Classes**:
  - Introduced custom error classes (`NotFoundError`, `UnauthorizedError`, `ForbiddenError`, `RateLimitError`, `InternalServerError`, etc.) in `errors.ts` for better error categorization and handling.

### Codebase Refactoring

* **Type Consolidation**:
  - Centralized type definitions (`Champion`, `Summoner`, `Match`, etc.) in `types/index.ts` for easier reuse. Updated imports across the codebase to use these consolidated types. [[1]](diffhunk://#diff-c25c26b7ef4053bf77d596e256590e712d6cd3d1e6dbb495f30f0d57a12ac3adR1-R9) [[2]](diffhunk://#diff-be00a103f43354251952c046771b2cb38845b8fd5636443aef9c6386f479b156L1-R1) [[3]](diffhunk://#diff-21cbda3607cedd9b895b9b532f99af690f858e2ecbbee5abe278fcf5e296a443L9-R15) [[4]](diffhunk://#diff-21cbda3607cedd9b895b9b532f99af690f858e2ecbbee5abe278fcf5e296a443L69-R65) [[5]](diffhunk://#diff-21cbda3607cedd9b895b9b532f99af690f858e2ecbbee5abe278fcf5e296a443L139-R135)

* **Route Updates**:
  - Added the `/summoner` route to `routes.ts` and linked it to the new `searchSummonerController`. Removed unused commented-out routes. [[1]](diffhunk://#diff-6a738a995912a870a3f6d850ebeb43c53592815607081346f08ab2688fb29aa3R7) [[2]](diffhunk://#diff-6a738a995912a870a3f6d850ebeb43c53592815607081346f08ab2688fb29aa3L26-R27)

### Removed Deprecated Code

* Removed an unused `Champion` interface from `Champion.ts`.